### PR TITLE
js: data-display: Add a link to GrantNav

### DIFF
--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -180,6 +180,47 @@ var app = new Vue({
             if (grants.length == 0) { return null; }
             return grants;
         },
+        grantnavUrl: function () {
+            // TODO, look this up from the config
+            var url = 'https://grantnav.threesixtygiving.org/search?';
+
+            var searchParams = new URLSearchParams();
+
+            if (this.filters.awardDates.min || this.filters.awardDates.max || this.filters.orgtype.length) {
+                return null;
+            }
+
+            if (this.filters.awardAmount.min) {
+                searchParams.append('min_amount', this.filters.awardAmount.min);
+            }
+            if (this.filters.awardAmount.max) {
+                searchParams.append('max_amount', this.filters.awardAmount.max);
+            }
+
+            var text_query = '';
+            this.filters.area.forEach((area) => {
+                var area_prefix = area.slice(0, 3);
+                if (['E06', 'E07', 'E08', 'E09', 'N09', 'S12', 'W06'].includes(area_prefix)) {
+                    text_query += ' additional_data.recipientDistrictGeoCode:' + area;
+                } else if (['E12'].includes(area_prefix)) {
+                    text_query += ' additional_data.recipientOrganizationLocation.rgn:' + area;
+                } else if (['E92', 'N92', 'S92', 'W92'].includes(area_prefix)) {
+                    text_query += ' additional_data.recipientOrganizationLocation.ctry:' + area;
+                }
+            });
+            searchParams.append('query', text_query);
+
+            this.filters.funderTypes.forEach((funderType) => {
+                searchParams.append('fundingOrganizationTSGType', funderType)
+            });
+            this.filters.funders.forEach((funder) => {
+                searchParams.append('fundingOrganization', funder);
+            });
+            this.filters.grantProgrammes.forEach((grantProgramme) => {
+                searchParams.append('grantProgramme', grantProgramme);
+            });
+            return url + searchParams.toString();
+        },
     },
     watch: {
 

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -81,6 +81,14 @@
                 }}</a> licence.</template></template>
           <template v-else-if="sources.length == 1">Original filename: <code>{{ sources[0].title }}</code></template>
         </p>
+        <p>
+          <template v-if="grantnavUrl">
+            <a v-bind:href="grantnavUrl">See this in GrantNav</a>.
+          </template>
+          <template v-else>
+            Could not generate a link to GrantNav, as you query uses filters it does not support.
+          </template>
+        </p>
         <template v-if="sources.length > 1">
           <details class="header-group__excerpt">
             <summary>Data sources</summary>


### PR DESCRIPTION
https://github.com/ThreeSixtyGiving/insights-ng/issues/16

Area filters rely on extra keyword fields being added to GrantNav (ie. deploy https://github.com/ThreeSixtyGiving/grantnav/pull/815).

Using filters that are not supported results in a message instead of the link. Currently this includes orgtype, which we intend to leave this way, and awardDates, which we plan to add shortly.