### PR TITLE
templates: data-display: More specific msg about lack of GrantNav link

### DIFF
--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -86,7 +86,7 @@
             <a v-bind:href="grantnavUrl">See this in GrantNav</a>.
           </template>
           <template v-else>
-            Could not generate a link to GrantNav, as you query uses filters it does not support.
+            Could not generate a link to GrantNav, as your query uses the "Recipient type" filter which it does not support.
           </template>
         </p>
         <template v-if="sources.length > 1">


### PR DESCRIPTION
`orgtype` ("Recipient type") is the only filter that isn't supported at the moment.