### PR TITLE
commands: fetch_data: Fix `flask data geonames`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
         psql -c 'CREATE DATABASE "insights-ng";' -W -h localhost postgres postgres
         flask db upgrade
         flask data fetch --limit 1000
+        flask data geonames
     - name: Test with pytest
       run: python -m pytest
 

--- a/insights/commands/fetch_data.py
+++ b/insights/commands/fetch_data.py
@@ -274,7 +274,7 @@ def fetch_data(dataset, bulk_limit, limit):
 def fetch_data(url_template):
     opts = get_frontpage_options(with_url=False)
     click.echo("Fetching geonames")
-    for i in ["countries", "regions", "local_authorities"]:
+    for i in ["countries", "regions", "localAuthorities"]:
         count = 0
         click.echo(f"Fetching {i}")
         with click.progressbar(opts[i]) as bar:


### PR DESCRIPTION
https://github.com/ThreeSixtyGiving/insights-ng/issues/73

I'm not sure why this was working before.

I've tested this from an empty db, and everything looks fine.