### PR TITLE
js: data-display: Redirect to home page if no filters

### DIFF
--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -171,6 +171,7 @@ var app = new Vue({
             let activeFilters = [];
 
             if (!window.location.search && this.dataset == 'main'){
+                window.location.href = "/";
                 return activeFilters;
             }
 
@@ -367,6 +368,7 @@ var app = new Vue({
             /* If no search filters do nothing */
 
             if (!this.filtersApplied.length && this.dataset == 'main'){
+                window.location.href = '/'
                 return;
             }
 


### PR DESCRIPTION
Note that due to the debounce on applying filters there is a short delay
in this triggering so we keep the "no filters" message in the
application.

Fixes: https://github.com/ThreeSixtyGiving/insights-ng/issues/53