### PR TITLE
view/data-display: Add DATASET_EXPIRY_DAYS for use in template

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -42,6 +42,7 @@ def create_app():
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         MAPBOX_ACCESS_TOKEN=os.environ.get("MAPBOX_ACCESS_TOKEN"),
         URL_FETCH_ALLOW_LIST=settings.URL_FETCH_ALLOW_LIST,
+        DATASET_EXPIRY_DAYS=settings.DATASET_EXPIRY_DAYS,
         SECRET_KEY=secret_key(),
     )
 

--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -113,6 +113,7 @@ var app = new Vue({
     data() {
         return {
             dataset: DATASET,
+            datasetExpiryDays: DATASET_EXPIRY_DAYS,
             title: TITLE,
             subtitle: SUBTITLE,
             bin_labels: BIN_LABELS,

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -19,6 +19,7 @@
     const PAGE_URLS = {{ page_urls|tojson }};
     const TITLE = {{ title|tojson }};
     const SUBTITLE = {{ subtitle|tojson }};
+    const DATASET_EXPIRY_DAYS = {{ config.DATASET_EXPIRY_DAYS|tojson }};
   </script>
   <script type="module" src="{{ url_for('static', filename='js/data-display.js') }}"></script>
 {% endblock bodyscripts %}
@@ -167,9 +168,10 @@
 
   <main class="layout__content">
     <div class="layout__content-inner">
-      <div class="box box--orange" v-if="!filtersApplied.length && dataset == 'main'">
+      <div class="box box--orange" v-if="(!filtersApplied.length && dataset == 'main') | (summary.grants === 0 && dataset !== 'main')">
           <h3>No Dataset selected</h3>
           <p>There are currently no 360Giving datasets selected. <a href="/">Select a dataset.</a></p>
+          <p>Note: Datasets imported from GrantNav expire after {{datasetExpiryDays}} days.</p>
       </div>
 
       <template v-else>


### PR DESCRIPTION
We may have removed a dataset that was in an expired link. Add a message
to this effect with a link to GrantNav. This isn't the perfect solution
but better than leaving this state as an empty page.

Fixes: https://github.com/ThreeSixtyGiving/insights-ng/issues/76