### PR TITLE
templates: homepage: .hide-print bug

### DIFF
--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -47,8 +47,8 @@
     <div class="layout__content-inner">
       <div class="layout__header wrapper">
 
-        <div class="grid hide-print">
-          <div class="grid__1">
+        <div class="grid">
+          <div class="grid__1 hide-print">
             <a href="#" class="button material-icons" title="Print this page" style="float:right; margin-left: 5px;" onclick="window.print()">print</a>
           </div>
         <div>


### PR DESCRIPTION
.hide-print only printer icon, not all the summary boxes