### PR TITLE
templates: move 'From the 360Giving data registry' to Data Sources box

### DIFF
--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -78,8 +78,6 @@
             This data contains grants made in {{ summary.currencies.length }} different currencies.
             Only showing grants made in {{ currencyUsed }}.
           </template>
-          <strong v-if="dataset == 'main'">From the <a href="https://data.threesixtygiving.org/">360Giving data
-              registry</a></strong>
 
           <template v-if="sources.length == 1 && sources[0].distribution[0]"> | <a
               v-bind:href="sources[0].distribution[0].downloadURL">Download original file</a><br>

--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -148,7 +148,8 @@
       <p>Charity data is sourced from <a href="https://findthatcharity.uk/" target="_blank"
           rel="noreferrer">findthatcharity.uk</a> and postcode data from <a href="https://findthatpostcode.uk/"
           target="_blank" rel="noreferrer">postcodes.findthatcharity.uk</a>. Company data is fetched using Companies
-        House URIs. All external data is used under the <a
+        House URIs. Datasets are fetched from the <a href="https://data.threesixtygiving.org/" target="_blank"
+          rel="noreferrer">360Giving data registry</a>. All external data is used under the
           href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" target="_blank"
           rel="noreferrer">Open Government Licence</a>.</p>
       <p><a href="https://insights.threesixtygiving.org/about#data-sources">More about data sources</a></p>


### PR DESCRIPTION
Related to https://github.com/ThreeSixtyGiving/insights-ng/issues/70

"Do we need "From the 360Giving data registry" to be here so prominently? I think we could lose it altogether, or move it to the Data Sources box at the bottom of the home/landing page."