### PR TITLE
insights: templates: delete average grant asterisk

### DIFF
--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -154,7 +154,7 @@
               <div class="base-card__content">
                 <h2 class="base-card__title">{{ currency.mean | formatCurrency(currency.currency) }}{{ currency.mean |
                   getAmountSuffix(true) }}</h2>
-                <p class="base-card__text">Average Grant*</p>
+                <p class="base-card__text">Average Grant</p>
               </div>
             </div>
           </div>

--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -94,7 +94,7 @@
                 <h2 class="base-card__title">{{ datasetSelect.dataset_stats.amount_average | formatCurrency("GBP") }}{{
                   datasetSelect.dataset_stats.amount_average |
                   getAmountSuffix(true) }}</h2>
-                <p class="base-card__text">Average Grant*</p>
+                <p class="base-card__text">Average Grant</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
related to https://github.com/ThreeSixtyGiving/insights-ng/issues/70

"Why does "Average Grant" have an asterisk in the headline stats? I can't see where I'm meant to go to read the related note"