### PR TITLE
templates: homepage: convert 'map' and 'data sources' links into buttons

### DIFF
--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -126,7 +126,7 @@
       <div>
         <hr class="separator-light">
         <p v-if="dataset == 'Regions'">This type of region data is currently only available for England (UK).</p>
-        <p>Total {{dataset}} {{datasetSelect[key].length}}. <a v-if="dataset == 'Regions' || dataset == 'Countries' || dataset == 'Local authorities'" href="#map">Map.</a></p>
+        <p>Total {{dataset}} {{datasetSelect[key].length}}. <a class="button" v-if="dataset == 'Regions' || dataset == 'Countries' || dataset == 'Local authorities'" href="#map">View on Map below</a></p>
 
      </div>
     </chart-card>
@@ -154,7 +154,7 @@
           rel="noreferrer">360Giving data registry</a>. All external data is used under the <a
           href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" target="_blank"
           rel="noreferrer">Open Government Licence</a>.</p>
-      <p><a href="/about#data-sources">More about data sources</a></p>
+      <p><a class="button" href="/about#data-sources">More about data sources</a></p>
 
     </chart-card>
 


### PR DESCRIPTION
relates to #70 
<img width="397" alt="Screen Shot 2022-02-11 at 11 54 47" src="https://user-images.githubusercontent.com/9610927/153587255-513b6e5d-bb85-45ea-b31b-4ba13b887d4c.png">
<img width="1040" alt="Screen Shot 2022-02-11 at 11 54 35" src="https://user-images.githubusercontent.com/9610927/153587266-a5b3b9e0-d624-4985-a553-652243b6e129.png">

