### PR TITLE
templates/js: Refactor regions/countries work

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "postdeploy": "flask db upgrade"
+      "postdeploy": "flask db upgrade && flask cache clear --homepage"
     }
   },
   "cron": [

--- a/insights/commands/cache.py
+++ b/insights/commands/cache.py
@@ -57,7 +57,17 @@ def warm_cache(url):
         time.sleep(4)
 
 
-@cli.command("expire")
-def expire_cache():
+@cli.command("clear")
+@click.option(
+    "--homepage",
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="Only clear homepage cache",
+)
+def clear_cache(homepage):
     with current_app.app_context():
-        Cache(current_app).clear()
+        if homepage:
+            Cache(current_app).delete("home_page")
+        else:
+            Cache(current_app).clear()

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -426,7 +426,7 @@
             <p v-if="chartMissing('byCountryRegion')">
               {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have enough information to determine geography.
             </p>
-            <p>This type of region data is currently only available for England (UK).</p>
+            <p>This type of region data is only available for England (UK).</p>
           </div>
         </chart-card>
 

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -372,9 +372,38 @@
           <h3>Grants locations</h3>
         </div>
 
+      <!-- countries -->
+      <chart-card color="red" v-bind:loading="loading" v-if="chartN('byCountryRegion') > 0">
+        <chart-card-header title="Countries">
+          (number of grants)
+        </chart-card-header>
+        <ul class="bar-chart" v-if="chartData.byCountryRegion">
+          <li class="bar-chart__item"
+           v-for="(group, index) in chartBars('byCountryRegion', 'grants', 0, false)"
+           :style="group.style"
+           v-on:click.prevent="toggleInArray(filters.area, group.id)"
+           v-bind:class="{ 'hide-print' : group.inactive }"
+           v-if="group.id"
+           >
+            <label class="bar-chart__label small">
+              {{ group.label }}
+              <span v-if="group.label.length === 0">{{group.id}}</span>
+            </label>
+            <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+          </li>
+        </ul>
+        <div>
+          <hr class="separator-light">
+          <p>Based on {{ chartN('byCountryRegion') | formatNumber }} grants.</p>
+          <p v-if="chartMissing('byCountryRegion')">
+            {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have enough information to determine geography.
+          </p>
+        </div>
+      </chart-card>
+
         <!-- Regions -->
         <chart-card color="red" v-bind:loading="loading" v-if="chartN('byCountryRegion') > 0">
-          <chart-card-header title="UK region and country">
+          <chart-card-header title="Regions in England">
           (number of grants)
           </chart-card-header>
           <ul class="bar-chart" v-if="chartData.byCountryRegion">
@@ -382,22 +411,12 @@
               :style="group.style"
               v-bind:class="{ 'hide-print' : group.inactive }"
               v-on:click.prevent="toggleInArray(filters.area, group.id)"
+              v-if="group.id"
               >
                 <label class="bar-chart__label small">
-                  England - {{ group.label }}
+                  {{ group.label }}
                 </label>
 
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
-            </li>
-            <li class="bar-chart__item" v-for="(group, index) in chartBars('byCountryRegion', 'grants', 0, false)"
-              v-if="group.label != 'England'"
-              :style="group.style"
-              v-on:click.prevent="toggleInArray(filters.area, group.id)"
-              v-bind:class="{ 'hide-print' : group.inactive }"
-              >
-              <label class="bar-chart__label small">
-                {{ group.label }}
-              </label>
               <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
             </li>
           </ul>
@@ -405,8 +424,9 @@
             <hr class="separator-light">
             <p>Based on {{ chartN('byCountryRegion') | formatNumber }} grants.</p>
             <p v-if="chartMissing('byCountryRegion')">
-              {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have a region or country.
+              {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have enough information to determine geography.
             </p>
+            <p>This type of region data is currently only available for England (UK).</p>
           </div>
         </chart-card>
 

--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -106,9 +106,13 @@
     <div class="spacer-3"></div>
 
     <chart-card color="orange" v-bind:loading="loading" v-for="(dataset, key) in datasetSelectSections" class="spacer-3">
-      <chart-card-header v-bind:title="dataset">
+      <chart-card-header v-bind:title="'Regions in England'" v-if="dataset == 'Regions'">
         (number of grants)
       </chart-card-header>
+      <chart-card-header v-bind:title="dataset" v-else>
+        (number of grants)
+      </chart-card-header>
+
       <ul class="bar-chart" >
         <li class="bar-chart__item" v-for="(group, index) in datasetSelect[key]"
           v-bind:title="group.grant_count"


### PR DESCRIPTION
Small refactoring for the regions/countries work where we were seeing
confusing bar graphs which conflated regions and countries together.

Related: https://github.com/ThreeSixtyGiving/insights-ng/issues/62