### PR TITLE
templates: data-display: add funders name in title.

### DIFF
--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -55,7 +55,11 @@
                   <div class="hero__column hero__lead">
                     <h2 class="hero__title">{{ subtitle }}</h2>
                     <p class="hero__blurb">
-                        {{ title }}
+                        <template v-if="funders && funders.length <= 3">
+                          {{ funders.join(", ")}}
+                        </template>
+                        <template v-else>{{ title }}</template>
+
                         <template v-if="summary.minDate">
                           <template v-if="summary.minDate.slice(0,7) == summary.maxDate.slice(0,7)">
                             <small>in</small> {{ summary.minDate | formatDate('month') }}


### PR DESCRIPTION
Relates to https://github.com/ThreeSixtyGiving/insights-ng/issues/21

One funder with short name:
<img width="463" alt="Screen Shot 2022-02-14 at 13 56 18" src="https://user-images.githubusercontent.com/9610927/153882903-fbe8edc0-630e-4225-ada4-8c21e2d58132.png">

One funder with long name:
<img width="581" alt="Screen Shot 2022-02-14 at 13 55 48" src="https://user-images.githubusercontent.com/9610927/153882917-26a88c64-476d-4ca4-97cc-ec5d8b9706aa.png">

Three funders:
<img width="567" alt="Screen Shot 2022-02-14 at 14 46 51" src="https://user-images.githubusercontent.com/9610927/153886865-8e0388df-efaa-4665-a537-96c0367820d3.png">

More than three funders:
<img width="468" alt="Screen Shot 2022-02-14 at 13 57 16" src="https://user-images.githubusercontent.com/9610927/153882929-7aa1713b-cfb3-46c2-acb6-57af5e5c4a10.png">
