### PR TITLE
js/templates: Remove and rework choropleth widget

### DIFF
--- a/insights/static/js/homepage.js
+++ b/insights/static/js/homepage.js
@@ -8,10 +8,7 @@ Vue.filter('formatNumberSuffix', formatNumberSuffix);
 
 import { choropleth } from './components/choropleth.js';
 
-import { mapboxMap } from './components/map.js';
-Vue.component('mapbox-map', mapboxMap);
 Vue.component('choropleth', choropleth);
-Vue.component('multi-select', window.VueMultiselect.default);
 
 var app = new Vue({
     el: '#app',
@@ -42,6 +39,7 @@ var app = new Vue({
                 regions: "",
                 localAuthorities: "",
             },
+            choroplethData: [],
             maxGrantCounts: {}, /* cache of max count */
         }
     },
@@ -67,6 +65,22 @@ var app = new Vue({
 
     },
     methods: {
+        dataForChoropleth: function () {
+            return [
+                {
+                    layerName: "regionCountryLayer",
+                    areas: this.datasetSelect["countries"].concat(this.datasetSelect["regions"]),
+                    layerBoundariesJsonFile: "country_region.geojson",
+                    // click handler?
+                },
+                {
+                    layerName: "laLayer",
+                    areas: this.datasetSelect["localAuthorities"],
+                    layerBoundariesJsonFile: "lalt.geojson",
+                    // click handler?
+                }
+            ];
+        },
         getDatasetOptions: function (field) {
             return this.datasetSelect[field];
         },
@@ -120,6 +134,11 @@ var app = new Vue({
         openFileDialog: function(){
             this.$refs.uploadFileInput.click();
         }
-        },
+    },
+
+    mounted: function(){
+        this.choroplethData = this.dataForChoropleth();
+
+    },
 
 });

--- a/insights/templates/base.html.j2
+++ b/insights/templates/base.html.j2
@@ -10,8 +10,6 @@
     rel="stylesheet">
   <link rel="shortcut icon" href="{{ url_for('static', filename='images/favicon/favicon.ico') }}" />
 
-  <link rel="stylesheet" href="https://unpkg.com/vue-multiselect@2.1.0/dist/vue-multiselect.min.css">
-
   {% if config.ENV == 'development' %}
   <script src="https://cdn.jsdelivr.net/npm/vue@2/dist/vue.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
@@ -25,8 +23,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.4.1/leaflet.markercluster.js"
           integrity="sha256-WL6HHfYfbFEkZOFdsJQeY7lJG/E5airjvqbznghUzRw=" crossorigin="anonymous"></script>
   <script src="{{ url_for('static', filename='js/lib/leaflet.groupedlayercontrol.js') }}"></script>
-
-  <script src="https://unpkg.com/vue-multiselect@2.1.0"></script>
 
   {% block headscripts %}
   {% endblock headscripts %}

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -434,31 +434,19 @@
           </div>
         </chart-card>
 
-        <!-- map -->
-        <div class="grid__all">
-          <div class="base-card base-card--red base-card--left">
-            <div style="padding-left: 4px">
-              <mapbox-map container="grants-map" height="500px" :markers="geoGrants"></mapbox-map>
-            </div>
-            <div class="base-card__content">
-              <chart-card-header title="Grant Locations">
-              (number of grants)
-              </chart-card-header>
-              <!-- https://github.com/ThreeSixtyGiving/insights-ng/issues/88
-              <div class="align-left margin-bottom:1">
-                <a :href="mapUrl" class="button button--small button--red align-left">View this map on its own page</a>
-              </div>
-              --->
-              <div v-if="geoGrants">
-                <hr class="separator-light">
-                <p>Based on {{ geoGrants.length | formatNumber }} grants.</p>
-                <p v-if="chartMissing('byCountryRegion')">
-                  {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have a location available.
-                </p>
-              </div>
-            </div>
+        <!-- choropleth -->
+        <chart-card color="red">
+          <chart-card-header title="Distribution of Grants by location"></chart-card-header>
+          <a name="map"></a>
+          <choropleth class="base-card__content" v-bind:data="dataForChoropleth()" container="ch-1" height="680px" :zoom-control="false"></choropleth>
+          <div>
+            <hr class="separator-light">
+            <p>Click on an area to view number of grants.</p>
+            <p>
+              {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have location data available.
+            </p>
           </div>
-        </div>
+        </chart-card>
 
         <!-- Source of location information -->
         <chart-card color="red" v-bind:loading="loading" v-if="chartN('byGeoSource') > 0">
@@ -482,12 +470,6 @@
           </div>
         </chart-card>
 
-        <chart-card color="red" v-bind:loading="loading" v-if="!geoGrants || geoGrants.length == 0">
-          <chart-card-header title="No location data shown"></chart-card-header>
-          <p>
-            {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have location data available.
-          </p>
-        </chart-card>
       </div> <!-- /end grid -->
 
       <div class="spacer-3"></div>

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -442,7 +442,7 @@
           <div>
             <hr class="separator-light">
             <p>Click on an area to view number of grants.</p>
-            <p>
+            <p v-if="chartMissing('byCountryRegion')">
               {{ chartMissing('byCountryRegion') | formatNumber }} grants did not have location data available.
             </p>
           </div>

--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -137,11 +137,12 @@
 
     <!-- choropleth -->
     <chart-card color="teal">
-      <chart-card-header title="Regional Distribution by number of Grants"></chart-card-header>
+      <chart-card-header title="Distribution of Grants by location"></chart-card-header>
       <a name="map"></a>
-      <choropleth class="base-card__content" container="ch-1" height="680px"></choropleth>
+      <choropleth class="base-card__content" v-bind:data="choroplethData" container="ch-1" height="680px" :zoom-control="true"></choropleth>
       <div>
         <hr class="separator-light">
+        <p>Click on an area to view number of grants.</p>
         <p>Zoom into a Country/Region to view Local Authority-level data.</p>
       </div>
     </chart-card>


### PR DESCRIPTION
Remove map widget in favour of a second choropleth on the data page.
This gives a better overview of the distribution of grant locations by
geographical areas.

The choropleth widget has been refactored to be more generic to be able
to operate on both home and data pages. Some corner cases remain still
to be neatened up.

Related: https://github.com/ThreeSixtyGiving/insights-ng/issues/62