### PR TITLE
views/file_upload: Optimise loading data from grantnav

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -24,7 +24,7 @@ from insights.data import get_frontpage_options, get_funder_names
 from insights.db import GeoName, Publisher, Grant, db, migrate
 from insights.schema import schema
 from insights.utils import list_to_string
-from insights.file_upload import upload_file, fetch_file_from_url
+from insights.file_upload import upload_file, fetch_file_from_grantnav_url
 
 __version__ = "0.1.0"
 
@@ -117,7 +117,7 @@ def create_app():
         # Loading data from GrantNav avoid the cache mechanism
         if request.args.get("url"):
             try:
-                return redirect(fetch_file_from_url(request.args.get("url")))
+                return redirect(fetch_file_from_grantnav_url(request.args.get("url")))
             except Exception as e:
                 flash("Could not fetch from URL:" + repr(e), "error")
                 return render_template(

--- a/tests/test_from_url.py
+++ b/tests/test_from_url.py
@@ -60,7 +60,6 @@ def test_fetch_from_url(m, client, url):
 
 @pytest.mark.parametrize("url", [
     "https://raw.githubusercontent.com/ThreeSixtyGiving/standard/master/schema/360-giving-package-schema.json",
-    "https://grantnav.threesixtygiving.org/grants/broken-grants.csv",
 ])
 def test_fetch_from_url_broken(m, client, url):
     rv = client.get("/?url=" + url, follow_redirects=True)


### PR DESCRIPTION
Instead of loading the JSON download file into memory and then passing
it through a validator we stream the data from grantnav and take each
line in the data as a grant object and save it.

Fixes: https://github.com/ThreeSixtyGiving/insights-ng/issues/137