### PR TITLE
commands: fetch_data: Switch away from kwargs for publisher

### DIFF
--- a/insights/commands/fetch_data.py
+++ b/insights/commands/fetch_data.py
@@ -158,7 +158,16 @@ def fetch_data(dataset, bulk_limit, limit):
     )
     for row in source_result:
         # create the publisher
-        publisher = Publisher(**row.data["publisher"])
+        publisher_data = row.data["publisher"]
+
+        publisher = Publisher(
+            prefix=publisher_data["prefix"],
+            name=publisher_data["name"],
+            website=publisher_data["website"],
+            logo=publisher_data["logo"],
+            last_published=publisher_data["last_published"],
+        )
+
         db.session.merge(publisher)
         db.session.commit()
 


### PR DESCRIPTION
Publisher data may (and has changed) this is a json object in the
datastore which isn't defined by the standard so we can't assume a 1:1
mapping of fields in the schema with fields from the datastore.