### PR TITLE
charts: Update numbers to use accountancy commas

### DIFF
--- a/insights/static/js/components/bar-chart.js
+++ b/insights/static/js/components/bar-chart.js
@@ -41,6 +41,9 @@ export const barChart = {
                             display: false,
                         },
                         ticks: {
+                          userCallback(value) {
+                            return value.toLocaleString()
+                          },
                             beginAtZero: true,
                             precision: 0,
                         },

--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -611,7 +611,7 @@ var app = new Vue({
                     areas: areas,
                     layerBoundariesJsonFile: "country_region.geojson",
                     popupHandler: function(layer){
-                        return `<a href="#" data-filter="area" data-area="${layer.feature.properties.areaId}" onClick="this.dispatchEvent(new Event('map-select', {bubbles: true}))" >${layer.feature.properties.name} : ${layer.feature.properties.grantCount} grants</a>`;
+                        return `<a href="#" data-filter="area" data-area="${layer.feature.properties.areaId}" onClick="this.dispatchEvent(new Event('map-select', {bubbles: true}))" >${layer.feature.properties.name} : ${layer.feature.properties.grantCount.toLocaleString()} grants</a>`;
                     },
                 },
                 {
@@ -619,7 +619,7 @@ var app = new Vue({
                     areas: laAreas,
                     layerBoundariesJsonFile: "lalt.geojson",
                     popupHandler: function(layer){
-                        return `<a href="#" data-filter="localAuthorities" data-area="${layer.feature.properties.areaId}" onClick="this.dispatchEvent(new Event('map-select', {bubbles: true}))" >${layer.feature.properties.name} : ${layer.feature.properties.grantCount} grants</a>`;
+                        return `<a href="#" data-filter="localAuthorities" data-area="${layer.feature.properties.areaId}" onClick="this.dispatchEvent(new Event('map-select', {bubbles: true}))" >${layer.feature.properties.name} : ${layer.feature.properties.grantCount.toLocaleString()} grants</a>`;
                     },
                 }
             ]

--- a/insights/static/js/homepage.js
+++ b/insights/static/js/homepage.js
@@ -72,7 +72,7 @@ var app = new Vue({
                     areas: this.datasetSelect["countries"].concat(this.datasetSelect["regions"]),
                     layerBoundariesJsonFile: "country_region.geojson",
                     popupHandler: function(layer){
-                        return `<a href="/data?area=${layer.feature.properties.areaId}">${layer.feature.properties.name} : ${layer.feature.properties.grantCount} grants`;
+                        return `<a href="/data?area=${layer.feature.properties.areaId}">${layer.feature.properties.name} : ${layer.feature.properties.grantCount.toLocaleString()} grants`;
                     },
                 },
                 {
@@ -80,7 +80,7 @@ var app = new Vue({
                     areas: this.datasetSelect["localAuthorities"],
                     layerBoundariesJsonFile: "lalt.geojson",
                     popupHandler: function(layer){
-                        return `<a href="/data?area=${layer.feature.properties.areaId}">${layer.feature.properties.name} : ${layer.feature.properties.grantCount} grants`;
+                        return `<a href="/data?area=${layer.feature.properties.areaId}">${layer.feature.properties.name} : ${layer.feature.properties.grantCount.toLocaleString()} grants`;
                     },
                 }
             ];

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -215,7 +215,7 @@
                   v-bind:class="{ 'hide-print' : group.inactive }"
                   :style="group.style" v-on:click="toggleInArray(filters.funders, group.id)">
                   <label class="bar-chart__label small">{{ group.label }}</label>
-                  <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+                  <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
                 </li>
             </ul>
             <input type="text" v-model="find.funder" placeholder="Find a funder" class="search-field" v-if="safeLength(chartData.byFunder) + safeLength(inactiveChartData.byFunder) > 10"  />
@@ -241,7 +241,7 @@
               v-on:click="toggleInArray(filters.funderTypes, group.id)"
               >
               <label class="bar-chart__label small">{{ group.label }}</a></label>
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></div>
             </li>
           </ul>
 
@@ -266,7 +266,7 @@
                 v-bind:class="{ 'hide-print' : group.inactive }"
                 v-on:click="applyAmountAwardedFilter(group)">
                <label class="bar-chart__label">{{ group.label }}</label>
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
 
@@ -354,7 +354,7 @@
             ref="byGrantProgrammeItem"
             >
             <label class="bar-chart__label small">{{ group.label }}</label>
-            <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+            <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
           </li>
         </ul>
         <input type="text" v-model="find.grantProgramme" placeholder="Find a programme" class="search-field" v-if="safeLength(chartData.byGrantProgramme) + safeLength(inactiveChartData.byGrantProgramme) > 10"  />
@@ -393,7 +393,7 @@
               {{ group.label }}
               <span v-if="group.label.length === 0">{{group.id}}</span>
             </label>
-            <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+            <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
           </li>
         </ul>
         <div>
@@ -421,7 +421,7 @@
                   {{ group.label }}
                 </label>
 
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
           <div>
@@ -452,7 +452,7 @@
                   {{ group.label }}
                 </label>
 
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
           <input type="text" v-model="find.localAuthority" placeholder="Find a local authority" class="search-field" v-if="safeLength(chartData.byLocalAuthority) + safeLength(inactiveChartData.byLocalAuthority) > 10"  />
@@ -492,7 +492,7 @@
               style="cursor: unset;"
               :style="group.style">
               <label class="bar-chart__label small" style="cursor: unset;">{{ group.label }}</label>
-              <div class="bar-chart__bar"><span></span></div>
+              <div class="bar-chart__bar"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
           <div>
@@ -525,7 +525,7 @@
               v-on:click="toggleInArray(filters.orgtype, group.id)"
             >
               <label class="bar-chart__label small" >{{ group.label }}</label>
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
 
@@ -553,7 +553,7 @@
               style="cursor: unset;"
               :style="group.style">
               <label class="bar-chart__label" style="cursor: unset;">{{ group.label }}</label>
-              <div class="bar-chart__bar"><span></span></div>
+              <div class="bar-chart__bar"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
           <div>
@@ -585,7 +585,7 @@
               style="cursor: unset;"
              :style="group.style">
               <label class="bar-chart__label" style="cursor: unset;" >{{ group.label }}</label>
-              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span></span></div>
+              <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
 <!--          <filter-item title="Recipient age">

--- a/insights/templates/homepage.vue.j2
+++ b/insights/templates/homepage.vue.j2
@@ -122,7 +122,7 @@
           v-on:click="openDataPage(key, group.id)"
           >
           <label class="bar-chart__label small">{{ group.name }}</label>
-          <div class="bar-chart__bar"><span></span></div>
+          <div class="bar-chart__bar"><span v-bind:data-val="group.grant_count.toLocaleString()"></span></div>
         </li>
       </ul>
       <input v-if="datasetSelect[key].length > 10" class="search-field" v-model="find[key]" v-bind:placeholder="'Find '+dataset" />


### PR DESCRIPTION
## Summary
+ Update charts & maps to use `toLocaleString()` to display accountancy commas wherever possible

Fixes: https://github.com/ThreeSixtyGiving/360insights/issues/55 (relies upon https://github.com/ThreeSixtyGiving/360-ds/pull/91)

## Verify
1. Load Insights
2. All charts (and maps) should now display numbers > 999 with accountancy commas, i.e. previously `1000`, now `1,000`