### PR TITLE
insights: data: Remove 'All grants'

### DIFF
--- a/insights/data.py
+++ b/insights/data.py
@@ -39,15 +39,7 @@ def get_frontpage_options(dataset=DEFAULT_DATASET, with_url=True):
             ],
             key=lambda x: -x["grant_count"],
         ),
-        funderTypes=[
-            {
-                "id": "all",
-                "name": "All grants",
-                "url": url_for("data") if with_url else None,
-                **all_grants[dataset],
-            }
-        ]
-        + sorted(
+        funderTypes=sorted(
             [
                 {
                     "id": k,


### PR DESCRIPTION
## Summary
Remove 'All grants' computed result from 'Funding Organisation Types' chart

Fixes: https://github.com/ThreeSixtyGiving/360insights/issues/158

## Verify
1. Visit the homepage
2. View the 'Funding Organisation Types' chart
3. The 'All grants' bar should no longer appear