### PR TITLE
ml/clearer-non-interactive-charts

### DIFF
--- a/insights/static/css/main.css
+++ b/insights/static/css/main.css
@@ -5592,27 +5592,27 @@ ul.dataset-select > li {
 .base-card--yellow .bar-chart__bar > span {
   background-color: var(--color-yellow); }
 
-.base-card--yellow .bar-chart__bar > span:hover {
+.base-card--yellow .bar-chart:not(.non-interactive) .bar-chart__bar > span:hover {
   background-color: var(--color-yellow-dark); }
 
 .base-card--red .bar-chart__bar > span {
   background-color: var(--color-red);
   opacity: 0.9; }
 
-.base-card--red .bar-chart__bar:hover > span {
+.base-card--red .bar-chart:not(.non-interactive) .bar-chart__bar:hover > span {
   background-color: var(--color-red);
   opacity: 1; }
 
 .base-card--teal .bar-chart__bar > span {
   background-color: var(--color-teal); }
 
-.base-card--teal .bar-chart__bar:hover > span {
+.base-card--teal .bar-chart:not(.non-interactive) .bar-chart__bar:hover > span {
   background-color: var(--color-teal-dark); }
 
 .base-card--orange .bar-chart__bar > span {
   background-color: var(--color-orange); }
 
-.base-card--orange .bar-chart__bar:hover > span {
+.base-card--orange .bar-chart:not(.non-interactive) .bar-chart__bar:hover > span {
   background-color: var(--color-orange-dark); }
 
 .base-card__header {
@@ -5626,10 +5626,11 @@ ul.dataset-select > li {
   overflow-y: auto;
   overflow-x: hidden; }
 
-.bar-chart li, label {
+.bar-chart:not(.non-interactive) li,
+.bar-chart:not(.non-interactive) label {
   cursor: pointer; }
 
-.bar-chart label:hover {
+.bar-chart:not(.non-interactive) label:hover {
   color: var(--color-orange-dark); }
 
 .bar-chart__bar {

--- a/insights/static/js/data/card.js
+++ b/insights/static/js/data/card.js
@@ -57,12 +57,12 @@ const chartCardData = [
   {
     id: 'byOrgSize',
     title: 'Latest income of charity recipients',
-    instructions: 'Click on the bars or labels to select one or more ranges of latest incomes of charity recipients.'
+    instructions: ''
   },
   {
     id: 'byOrgAge',
     title: 'Age of recipient organisations',
-    instructions: 'Click on the bars or labels to select one or more age ranges of recipients.'
+    instructions: ''
   }
 ]
 

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -558,9 +558,8 @@
           <chart-card-header :title="getChartCardData('byOrgSize')[0].title">
           (number of grants)
           </chart-card-header>
-          <ul class="bar-chart" v-if="chartData.byOrgSize">
+          <ul class="bar-chart non-interactive" v-if="chartData.byOrgSize">
             <li class="bar-chart__item" v-for="(group, index) in chartBars('byOrgSize')"
-              style="cursor: unset;"
               :style="group.style">
               <label class="bar-chart__label" style="cursor: unset;">{{ group.label }}</label>
               <div class="bar-chart__bar"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
@@ -591,9 +590,8 @@
           <chart-card-header :title="getChartCardData('byOrgAge')[0].title">
             (number of grants)
           </chart-card-header>
-          <ul class="bar-chart" v-if="chartData.byOrgAge">
+          <ul class="bar-chart non-interactive" v-if="chartData.byOrgAge">
             <li class="bar-chart__item" v-for="(group, index) in chartBars('byOrgAge')"
-              style="cursor: unset;"
              :style="group.style">
               <label class="bar-chart__label" style="cursor: unset;" >{{ group.label }}</label>
               <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -561,7 +561,7 @@
           <ul class="bar-chart non-interactive" v-if="chartData.byOrgSize">
             <li class="bar-chart__item" v-for="(group, index) in chartBars('byOrgSize')"
               :style="group.style">
-              <label class="bar-chart__label" style="cursor: unset;">{{ group.label }}</label>
+              <label class="bar-chart__label">{{ group.label }}</label>
               <div class="bar-chart__bar"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>
@@ -593,7 +593,7 @@
           <ul class="bar-chart non-interactive" v-if="chartData.byOrgAge">
             <li class="bar-chart__item" v-for="(group, index) in chartBars('byOrgAge')"
              :style="group.style">
-              <label class="bar-chart__label" style="cursor: unset;" >{{ group.label }}</label>
+              <label class="bar-chart__label">{{ group.label }}</label>
               <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
+ Add `:not(.non-interactive)` condition to bar chart interaction styles (via 360-DS)
+ Add `.non-interactive` class to non-interactive charts
+ Remove interaction instructions for non-interactive charts

Fixes https://github.com/ThreeSixtyGiving/360insights/issues/174

## Verify
1. View the last two charts on the data display page, 'Latest Income' and 'Age'
2. Verify the text copy no longer indicates the charts are interactive
3. Attempt to interact with the charts; the bars and labels will no longer show interactive elements (colour will not change on `:hover`, cursor will not change to pointer)