### PR TITLE
ml/numeric-abbreviations

### DIFF
--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -156,7 +156,8 @@
           <div class="grid__1">
             <div class="base-card base-card--yellow">
               <div class="base-card__content">
-                <h2 class="base-card__title">{{ currency.total | formatCurrency(currency.currency) }}</h2>
+                <h2 class="base-card__title">{{ currency.total | formatCurrency(currency.currency) }}{{ currency.total |
+                getAmountSuffix(true) }}</h2>
                 <p class="base-card__text">Total</p>
               </div>
             </div>

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -146,8 +146,7 @@
         <div class="grid__1">
           <div class="base-card base-card--teal">
             <div class="base-card__content">
-              <h2 class="base-card__title">{{ summary.recipients | formatNumberSuffix }}{{ summary.recipients |
-                getAmountSuffix(true) }}</h2>
+              <h2 class="base-card__title">{{ summary.recipients.toLocaleString() }}</h2>
               <p class="base-card__text">Recipients</p>
             </div>
           </div>
@@ -158,7 +157,7 @@
             <div class="base-card base-card--yellow">
               <div class="base-card__content">
                 <h2 class="base-card__title">{{ currency.total | formatCurrency(currency.currency) }}</h2>
-                <p class="base-card__text">{{ currency.total | getAmountSuffix }} total</p>
+                <p class="base-card__text">Total</p>
               </div>
             </div>
           </div>
@@ -166,8 +165,7 @@
           <div class="grid__1">
             <div class="base-card base-card--black">
               <div class="base-card__content">
-                <h2 class="base-card__title">{{ summary.funders | formatNumberSuffix }}{{ summary.funders |
-                  getAmountSuffix(true) }}</h2>
+                <h2 class="base-card__title">{{ summary.funders.toLocaleString() }}</h2>
                 <p class="base-card__text">Funders</p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
+ Use numeric abbreviations with currency for grants total
+ Don't round funder or recipient numbers

Fixes https://github.com/ThreeSixtyGiving/360insights/issues/164

## Verify
1. View the summary cards
2. Verify grants are rounded and use numerical abbreviation (unchanged)
3. Verify recipients are not rounded, don't use numerical abbreviation, and do use accountancy commas
4. Verify totals are rounded and use numerical abbreviation as well as currency units
5. Verify funders numbers are not rounded, don't use numerical abbreviation, and do use accountancy commas (where appropriate)