### PR TITLE
frontend: charts: Add copy indicating non-interactive charts

### DIFF
--- a/insights/static/js/data/card.js
+++ b/insights/static/js/data/card.js
@@ -47,7 +47,7 @@ const chartCardData = [
   {
     id: 'byGeoSource',
     title: 'Source of location information',
-    instructions: ''
+    instructions: 'Data cannot be filtered using this chart.'
   },
   {
     id: 'byOrgType',
@@ -57,12 +57,12 @@ const chartCardData = [
   {
     id: 'byOrgSize',
     title: 'Latest income of charity recipients',
-    instructions: ''
+    instructions: 'Data cannot be filtered using this chart.'
   },
   {
     id: 'byOrgAge',
     title: 'Age of recipient organisations',
-    instructions: ''
+    instructions: 'Data cannot be filtered using this chart.'
   }
 ]
 


### PR DESCRIPTION
## Summary
+ Add inverse copy indicating non-interactive charts are not clickable

Fixes https://github.com/ThreeSixtyGiving/360insights/issues/181

## Verify
1. Visit the homepage or a data display page
2. Ensure the charts 'Source of location information', 'Latest income of charity recipients' and 'Age of recipient organisations' have text copy indicating they are not clickable