### PR TITLE
ml/older-award-dates

### DIFF
--- a/insights/static/js/components/bar-chart.js
+++ b/insights/static/js/components/bar-chart.js
@@ -7,6 +7,7 @@ if (window.navigator.languages) {
   language = window.navigator.userLanguage || window.navigator.language;
 }
 
+// Create empty dataset with 'Older' entry to be populated with this.chartData entries
 const compiledData = {
   labels: ['Older'],
   datasets: [{
@@ -16,6 +17,7 @@ const compiledData = {
   }]
 };
 
+// Check if date range is filtered
 let params = new URLSearchParams(document.location.search);
 let awardDates = false
 let awardMinYear = null;
@@ -44,11 +46,14 @@ export const barChart = {
         ) / MS_IN_DAY
       )
 
+      
       this.chartData.labels.forEach((label, index) => {
         const daysOld = Math.ceil((date - new Date(label)) / MS_IN_DAY);
         if (daysOld > 365 * 20) {
+            // Push this.chartData older than 20 years into compiledData Older entry
             compiledData.datasets[0].data[0] += this.chartData.datasets[0].data[index];
         } else {
+            // Push all other data > 20 years old to compiledData dataset
             compiledData.labels.push(label);
             compiledData.datasets[0].data.push(this.chartData.datasets[0].data[index]);
         }
@@ -79,19 +84,23 @@ export const barChart = {
             ticks: {
               autoSkip: false,
               callback(value, index, ticks) {
+                // Parse and display date labels
                 if (value instanceof Date) {
                   const year = value.toLocaleString(language, { year: 'numeric' });
                   let label = null;
                   
                   if (daysRange >= 365) {
+                    // Hide date labels older than 20 years
                     if (date.getFullYear() - year >= 20) {
                       label = null;
                     } else if (year !== lastYearLabel) {
+                      // Show label on first instance of the year (prevents duplicates)
                       label = year;
                     } else {
                       label = null;
                     }
                   } else {
+                    // Show month and year if date range < 365 days
                     label = value.toLocaleString(language, { month: 'short', year: 'numeric' });
                   }
                   
@@ -99,6 +108,7 @@ export const barChart = {
 
                   return label;
                 } else {
+                  // Show 'Older' (non-date) label if date range isn't filtered
                   return awardDates ? null : value;
                 }
               }
@@ -125,6 +135,7 @@ export const barChart = {
     lastYearLabel = '';
   },
   mounted() {
+    // Switch dataset between original and 'Older' depending on if min date range filter
     !awardMinYear ? this.renderChart(compiledData, this.options) : this.renderChart(this.chartData, this.options);
   }
 }

--- a/insights/static/js/components/bar-chart.js
+++ b/insights/static/js/components/bar-chart.js
@@ -3,95 +3,102 @@ const date = new Date();
 
 let language;
 if (window.navigator.languages) {
-    language = window.navigator.languages[0];
+  language = window.navigator.languages[0];
 } else {
-    language = window.navigator.userLanguage || window.navigator.language;
+  language = window.navigator.userLanguage || window.navigator.language;
 }
 
-const newData = {
+const compiledData = {
   labels: ['Older'],
   datasets: [{
-      label: 'Data',
-      backgroundColor: '#F26202',
-      data: [],
+    label: 'Data',
+    backgroundColor: '#F26202',
+    data: [0]
   }]
 };
 
-export const barChart = {
-    extends: VueChartJs.Bar,
-    mixins: [VueChartJs.mixins.reactiveProp],
-    props: ['chartData', 'hideLegend', 'percentages'],
-    data() {
-        return {}
-    },
-    computed: {
-        options: function () {
-
-          this.chartData.labels.forEach((label, index) => {
-            const daysOld = Math.ceil((date - new Date(label)) / MS_IN_DAY);
-            if (daysOld > 365 * 20) {
-                newData.datasets[0].data[0] += this.chartData.datasets[0].data[index];
-            } else {
-                newData.labels.push(label);
-                newData.datasets[0].data.push(this.chartData.datasets[0].data[index]);
-            }
-          });
-
-            let params = new URLSearchParams(document.location.search);
-            let awardDates = false
-            for (const [key, value] of params) {
-              if (key.includes('awardDates')) {
-                awardDates = true
-              }
-            }
-            
-            var daysRange = Math.ceil(
-                (
-                    Math.max(...this.chartData.labels) - Math.min(...this.chartData.labels)
-                ) / MS_IN_DAY
-            )
-            return {
-                responsive: true,
-                legend: {
-                    display: (this.hideLegend ? false : true)
-                },
-                scales: {
-                    xAxes: [{
-                        gridLines: {
-                            display: false,
-                            offsetGridLines: true,
-                        },
-                        offset: true,
-                        ticks: {
-                          userCallback(value, index, ticks) {
-                            if (value instanceof Date) {
-                              const month = new Intl.DateTimeFormat(language, { month: 'long' }).format(value)
-                              const year = value.getUTCFullYear()
-                              return language.includes('en') ? `${month.substring(0,3)} ${year}` : `${month} ${year}`
-                            } else {
-                              return awardDates ? '' : value
-                            }
-                          }
-                        },
-                        display: true,
-                    }],
-                    yAxes: [{
-                        gridLines: {
-                            display: false,
-                        },
-                        ticks: {
-                          userCallback(value) {
-                            return value.toLocaleString()
-                          },
-                            beginAtZero: true,
-                            precision: 0,
-                        },
-                    }]
-                }
-            }
-        }
-    },
-    mounted() {
-        this.renderChart(newData, this.options)
+let params = new URLSearchParams(document.location.search);
+let awardDates = false
+let awardMinYear = null;
+for (const [key, value] of params) {
+  if (key.includes('awardDates.min')) {
+    awardDates = true;
+    if (key.includes('year')) {
+      awardMinYear = value;
     }
+  }
+}
+
+export const barChart = {
+  extends: VueChartJs.Bar,
+  mixins: [VueChartJs.mixins.reactiveProp],
+  props: ['chartData', 'hideLegend', 'percentages'],
+  data() {
+      return {}
+  },
+  computed: {
+    options: function () {
+
+      this.chartData.labels.forEach((label, index) => {
+        const daysOld = Math.ceil((date - new Date(label)) / MS_IN_DAY);
+        if (daysOld > 365 * 20) {
+            compiledData.datasets[0].data[0] += this.chartData.datasets[0].data[index];
+        } else {
+            compiledData.labels.push(label);
+            compiledData.datasets[0].data.push(this.chartData.datasets[0].data[index]);
+        }
+      });
+
+      return {
+        responsive: true,
+        legend: {
+          display: (this.hideLegend ? false : true)
+        },
+        tooltips: { 
+          callbacks: {
+            title: function(tooltipItem, data) {
+              return tooltipItem[0].xLabel.toLocaleString(language, {dateStyle: 'medium', timeStyle: 'short'});
+            },
+            label: function(tooltipItem, data) {
+              return tooltipItem.yLabel.toLocaleString();
+            }
+          }
+        },
+        scales: {
+          xAxes: [{
+            gridLines: {
+              display: false,
+              offsetGridLines: true
+            },
+            offset: true,
+            ticks: {
+              userCallback(value, index, ticks) {
+                if (value instanceof Date) {
+                  return value.toLocaleString(language, { month: 'short', year: 'numeric' });
+                } else {
+                  return awardDates ? '' : value;
+                }
+              }
+            },
+            display: true,
+          }],
+          yAxes: [{
+            gridLines: {
+              display: false,
+            },
+            ticks: {
+              userCallback(value) {
+                return value.toLocaleString();
+              },
+                beginAtZero: true,
+                precision: 0
+            },
+          }]
+        }
+      }
+    }
+  },
+  mounted() {
+    !awardMinYear ? this.renderChart(compiledData, this.options) : this.renderChart(this.chartData, this.options)
+  }
 }

--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -369,7 +369,20 @@ var app = new Vue({
                 this.dataUrl = PAGE_URLS['data'];
             }
 
-            window.location.href = window.location.pathname + '?' + queryParams.toString();
+            let awardDates = false
+            for (const [key, value] of queryParams) {
+              if (key.includes('awardDates')) {
+                awardDates = true;
+              }
+            }
+            
+            // Reload page on awardDate filter change to prevent duplicate chart data entering state
+            if (awardDates) {
+              window.location.href = window.location.pathname + '?' + queryParams;
+            } else {
+              history.pushState(this.filters, '', "?" + queryParams.toString());
+            }
+
         },
         resetFilter(name) {
             if (this.filters[name].min || this.filters[name].max){

--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -368,7 +368,8 @@ var app = new Vue({
                 this.mapUrl = PAGE_URLS['map'];
                 this.dataUrl = PAGE_URLS['data'];
             }
-            history.pushState(this.filters, '', "?" + queryParams.toString());
+
+            window.location.href = window.location.pathname + '?' + queryParams.toString();
         },
         resetFilter(name) {
             if (this.filters[name].min || this.filters[name].max){


### PR DESCRIPTION
## Summary
+ Compile data older than 20 years into one 'Older' bar
+ Conditionally show 'Older' bar based on min date filter
+ Recalculate $x$-axis labels using custom categories rather than time-based automatic labels
+ Reload page on filter change

Fixes https://github.com/ThreeSixtyGiving/360insights/issues/187