### PR TITLE
frontend: charts: Reload page if > 1 filter

### DIFF
--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -370,14 +370,16 @@ var app = new Vue({
             }
 
             let awardDates = false
+            let queryParamLength = 0
             for (const [key, value] of queryParams) {
+              queryParamLength += 1
               if (key.includes('awardDates')) {
                 awardDates = true;
               }
             }
             
             // Reload page on awardDate filter change to prevent duplicate chart data entering state
-            if (awardDates) {
+            if (awardDates || queryParamLength > 1) {
               window.location.href = window.location.pathname + '?' + queryParams;
             } else {
               history.pushState(this.filters, '', "?" + queryParams.toString());

--- a/insights/templates/data-display.vue.j2
+++ b/insights/templates/data-display.vue.j2
@@ -305,7 +305,7 @@
                 :style="group.style"
                 v-bind:class="{ 'hide-print' : group.inactive }"
                 v-on:click="applyAmountAwardedFilter(group)">
-               <label class="bar-chart__label">{{ group.label }}</label>
+               <label class="bar-chart__label" style="white-space: nowrap;">{{ group.label }}</label>
               <div class="bar-chart__bar" v-bind:class="{ 'inactive-bar': group.inactive }"><span v-bind:data-val="group.value.toLocaleString()"></span></span></div>
             </li>
           </ul>


### PR DESCRIPTION
Fixes issue where award date chart displays multiple filters in series.

Also fixes https://github.com/ThreeSixtyGiving/360insights/issues/149