### PR TITLE
views: Add new redirect helper to support legacy links

### DIFF
--- a/insights/__init__.py
+++ b/insights/__init__.py
@@ -3,13 +3,14 @@ import os
 import random
 import string
 import sys
+import insights.redirect_helpers as redirect_helpers
 
 from flask import (
     Flask,
     render_template,
     url_for,
-    redirect,
     request,
+    redirect,
 )
 
 __version__ = "0.1.0"
@@ -56,6 +57,10 @@ def create_app():
 
     @app.route("/")
     def data():
+        # Check for legacy url 2024
+        if request.args.get("funders"):
+            return redirect_helpers.funders(request)
+
         return render_template(
             "data-display.vue.j2",
             context={
@@ -67,14 +72,11 @@ def create_app():
     @app.route("/data")
     def legacy_data():
         if request.args.get("funders"):
-            new_query = request.query_string.decode("utf-8").replace(
-                "funders", "fundingOrganization"
-            )
-            return redirect(f"/?{new_query}")
-
+            return redirect_helpers.funders(request)
         else:
             return redirect("/")
 
+    # Legacy redirect 2024
     @app.route("/file/<file_id>")
     def legacy_file(file_id):
         return redirect("/")

--- a/insights/redirect_helpers.py
+++ b/insights/redirect_helpers.py
@@ -1,0 +1,15 @@
+from flask import (
+    url_for,
+    redirect,
+)
+
+
+def funders(request):
+    """Rewrites query param funders to fundingOrganization for legacy 2024"""
+    newargs = request.args.copy()
+    funders = newargs.poplist("funders")
+    newargs.setlist("fundingOrganization", funders)
+
+    # Using flat=False to preserve multi keys
+    # see https://github.com/pallets/flask/issues/4893#issuecomment-1335957018
+    return redirect(url_for("data", **newargs.to_dict(flat=False)))


### PR DESCRIPTION
This adds support for `/?funder=orgid&funder=orgid` and refactors support for `/data?funder=orgid&funder=orgid` to make it re-usable in two places.

One improvement for future would be to add something on insights itself to let people know they're using an old style link. The 360-ds has an alert tag that could be used https://cdn.threesixtygiving.org/components/detail/alert-tag--default  (not particularly pretty but that might be part of the point!). 

@mariongalley @KDuerden 