### PR TITLE
data-display: Only remove query fields when not in "open query" mode

### DIFF
--- a/insights/static/js/data-display.js
+++ b/insights/static/js/data-display.js
@@ -78,12 +78,14 @@ var app = new Vue({
             this.grantnavUrl = `${this.grantnavBaseUrl}/search${url.search}`;
 
 
-            /* In insights these are not "public facing parameters" and only
-               apply to grantnav
+            /* In non-main insights (i.e. query restricted) these are not "public facing parameters" and only
+               apply to grantnav.
             */
-            urlSearch.delete("sort")
-            urlSearch.delete("query");
-            urlSearch.delete("default_field");
+            if (this.insightsConfig.query){
+                urlSearch.delete("sort")
+                urlSearch.delete("query");
+                urlSearch.delete("default_field");
+            }
 
             /* Update our browser url */
             history.pushState(null, '', `?${urlSearch.toString()}`);


### PR DESCRIPTION
When in main mode we don't want to restrict the query to the pre-defined one e.g. COL and want changes to reflect in both directions.

Fixes: https://github.com/ThreeSixtyGiving/360insights/issues/231